### PR TITLE
v0.0.2-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Content-Type: application/json
 Authorization: Bearer <token>
 
 {
-  "author": "test_user",
   "title": "Test topic",
   "text": "Some long content. Can be more than one sentence.",
   "tags": ["test", "documentation"]
@@ -42,11 +41,18 @@ Authorization: Bearer <token>
 
 Example response
 
-```http
+```
 HTTP/1.1 200 OK
-Content-Type: text/html
+Content-Type: application/json
 
-62b0a024c3151f3937ec92a7
+{
+  "id": "65e5fb4cb353e5f69dfd231b",
+  "createdAt": 1709570892538,
+  "updatedAt": 1709570892538,
+  "title": "Test topic",
+  "text": "Some long content. Can be more than one sentence.",
+  "tags": ["test", "documentation"]
+}
 ```
 
 ## Get note
@@ -66,7 +72,6 @@ Content-Type: application/json
 
 {
   "id": "62b0a024c3151f3937ec92a7",
-  "author": "test_user",
   "createdAt": 1655742500032,
   "updatedAt": 1655742500042,
   "title": "Test topic",
@@ -87,7 +92,7 @@ Authorization: Bearer <token>
 Example response
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 204 OK
 ```
 
 ## Update note
@@ -108,6 +113,16 @@ Example response
 
 ```http
 HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "65e5fb4cb353e5f69dfd231b",
+  "createdAt": 1709570892538,
+  "updatedAt": 1709571310597,
+  "title": "Updated test topic",
+  "text": "Some long content. Can be more than one sentence.",
+  "tags": ["test", "documentation"]
+}
 ```
 
 ## List notes
@@ -127,7 +142,6 @@ Content-Type: application/json
 
 [{
   "id": "62b0a024c3151f3937ec92a7",
-  "author": "test_user",
   "createdAt": 1655742500032,
   "updatedAt": 1655742500052,
   "title": "Updated test topic",
@@ -136,7 +150,6 @@ Content-Type: application/json
 },
 {
   "id": "62b0a024c3151f3937ec92a8",
-  "author": "test_user",
   "createdAt": 1655742500072,
   "updatedAt": 1655742500092,
   "title": "Another test topic",
@@ -150,6 +163,13 @@ Content-Type: application/json
 ## v0.0.1-alpha
 
 -   [x] No changes, compatibility tag
+
+## v0.0.2-alpha
+
+-   [x] APIs which do not have any content in response should return `HTTP 204` upon success
+-   [x] Fix documentation: create note API returns JSON, not plain text
+-   [x] Change axios `then` promise handling to top-level `await` when requesting public key from `notes-id`
+-   [x] Migrate to `ES6` modules
 
 # Known issues
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-express = require('express')
-morgan = require('morgan')
-mongoose = require('mongoose')
-cors = require('cors')
-jwt = require('jsonwebtoken')
-jwkToPem = require('jwk-to-pem')
-axios = require('axios')
-require('dotenv').config()
-Note = require('./models/note')
+import express from 'express'
+import morgan from 'morgan'
+import mongoose from 'mongoose'
+import cors from 'cors'
+import jwt from 'jsonwebtoken'
+import jwkToPem from 'jwk-to-pem'
+import axios from 'axios'
+import 'dotenv/config'
+import Note from './models/note.js'
 
 const app = express()
 const port = 3000
@@ -15,10 +15,7 @@ const port = 3000
 app.use(express.json())
 app.use(morgan('combined'))
 
-let myIDkeys = null
-axios.get(process.env.MYID_URL).then((resp) => {
-    myIDkeys = resp.data
-})
+const myIDkeys = (await axios.get(process.env.MYID_URL)).data
 
 app.use(
     cors({
@@ -39,11 +36,6 @@ app.listen(port, function () {
 
 app.get('/ping', async function (req, res) {
     res.status(200).send()
-})
-
-app.get('/test', async function (req, res) {
-    const u = getUserName(req)
-    res.status(200).send(u)
 })
 
 // Create note
@@ -99,7 +91,7 @@ app.get('/notes/:id', async function (req, res) {
 app.delete('/notes/:id', async function (req, res) {
     try {
         await Note.deleteOne({ author: getUserName(req), _id: req.params.id })
-        res.status(200).send()
+        res.status(204).send()
     } catch (e) {
         console.error(e)
         res.status(400).send()

--- a/models/note.js
+++ b/models/note.js
@@ -1,4 +1,4 @@
-mongoose = require("mongoose")
+import mongoose from 'mongoose'
 
 const schema = new mongoose.Schema({
     author: {
@@ -12,7 +12,7 @@ const schema = new mongoose.Schema({
     updatedAt: {
         type: Number,
         required: true,
-        default: () => Date.now()
+        default: () => Date.now(),
     },
     title: {
         type: String,
@@ -24,9 +24,9 @@ const schema = new mongoose.Schema({
     },
     tags: {
         type: Array,
-    }
+    },
 })
 
-const Note = mongoose.model("notes", schema)
+const Note = mongoose.model('notes', schema)
 
-module.exports = Note
+export default Note

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "description": "",
     "main": "index.js",
+    "type": "module",
     "scripts": {
         "start": "node index.js",
         "dev": "nodemon index.js",


### PR DESCRIPTION
-   [x] APIs which do not have any content in response should return `HTTP 204` upon success
-   [x] Fix documentation: create note API returns JSON, not plain text
-   [x] Change axios `then` promise handling to top-level `await` when requesting public key from `notes-id`
-   [x] Migrate to `ES6` modules